### PR TITLE
GH Actions using openapi CLI to split and rebundle the OAS spec.

### DIFF
--- a/.github/workflows/publishToPages.yml
+++ b/.github/workflows/publishToPages.yml
@@ -1,10 +1,10 @@
 name: Generate docs and publish to GH Pages
 on:
-  push:
+  push: #generate docs when changes are pushed to default branch for the file src/openAPI.yml
     branches:
       - develop
     paths:
-      - "src/**"
+      - "src/openapi.yml"
 
 jobs:
 

--- a/.github/workflows/rebundle.yml
+++ b/.github/workflows/rebundle.yml
@@ -1,0 +1,19 @@
+name: bundle OAS
+
+on:
+  workflow_dispatch: #manual trigger or ...
+  push: #when changes are pushed to default branch for any file in src/split
+    branches:
+      - develop
+    paths:
+      - "src/split/**"
+jobs:
+
+  rebundle:
+    runs-on: ubuntu-latest
+    name: Redoc Linter
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: CLI bundle #not to be confused with bundle docs to generate html
+        run: npx @redocly/openapi-cli bundle src/split/openapi.yaml --output src/openapi2.yaml

--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -1,0 +1,19 @@
+name: split OAS
+
+on:
+  workflow_dispatch: #manual trigger or ...
+  push: #when changes are pushed to default branch for the file src/openAPI.yml
+    branches:
+      - develop
+    paths:
+      - "src/openAPI.yml"
+jobs:
+
+  split:
+    runs-on: ubuntu-latest
+    name: Redoc Linter
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: CLI split
+        run: npx @redocly/openapi-cli split src/openapi.yaml --outDir='src/split'


### PR DESCRIPTION
This adds new GH Actions, and a minor change to the trigger for publishing html.