### PR TITLE
field name corrections

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -857,7 +857,7 @@ paths:
             application/json:
               schema:
                 properties:
-                  labels:
+                  tags:
                     type: array
                     items:
                       $ref: "#/components/schemas/Tag"
@@ -880,7 +880,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  protocol:
+                  tag:
                     $ref: "#/components/schemas/Tag"
         "400":
           $ref: "#/components/responses/BadRequest"


### PR DESCRIPTION
@VPatschka this is a trivial error correction, and there probably are many more errors in the YAML. Ideally, we could use this for  specifying both endpoints and schema for payload objects.
Eventually I think that we can make a script to automate IT tests from the openapi.yaml. It would be good to be able to guarantee that endpoints meet the spec, and there are a number of projects building tools for this. They seem immature, but improving.
I would like to have this be a real "single-source-of-truth" for the API, but some work remains ... 
Go ahead and merge. I'll think about how to add this as a JIRA issue or issues.